### PR TITLE
Feat: Read image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@biomejs/biome": "2.0.5",
         "@types/express": "4.17.23",
         "@types/node": "20.x",
-        "@types/vscode": "1.101.0",
+        "@types/vscode": "1.106.1",
         "concurrently": "9.2.0",
         "husky": "9.1.7",
         "lint-staged": "16.1.2",
@@ -25,7 +25,7 @@
         "typescript": "5.8.3"
       },
       "engines": {
-        "vscode": "^1.101.0"
+        "vscode": "^1.106.1"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -407,9 +407,9 @@
       }
     },
     "node_modules/@types/vscode": {
-      "version": "1.101.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.101.0.tgz",
-      "integrity": "sha512-ZWf0IWa+NGegdW3iU42AcDTFHWW7fApLdkdnBqwYEtHVIBGbTu0ZNQKP/kX3Ds/uMJXIMQNAojHR4vexCEEz5Q==",
+      "version": "1.106.1",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.106.1.tgz",
+      "integrity": "sha512-R/HV8u2h8CAddSbX8cjpdd7B8/GnE4UjgjpuGuHcbp1xV6yh4OeqU4L1pKjlwujCrSFS0MOpwJAIs/NexMB1fQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "@biomejs/biome": "2.0.5",
     "@types/express": "4.17.23",
     "@types/node": "20.x",
-    "@types/vscode": "1.101.0",
+    "@types/vscode": "1.106.1",
     "concurrently": "9.2.0",
     "husky": "9.1.7",
     "lint-staged": "16.1.2",
@@ -188,7 +188,7 @@
   },
   "extensionDependencies": [],
   "engines": {
-    "vscode": "^1.101.0"
+    "vscode": "^1.106.1"
   },
   "icon": "icon.png",
   "galleryBanner": {

--- a/src/converter/anthropicConverter.ts
+++ b/src/converter/anthropicConverter.ts
@@ -1,5 +1,6 @@
 import type {
   ContentBlock,
+  ImageBlockParam,
   Message,
   MessageCreateParams,
   RawMessageStreamEvent,
@@ -11,6 +12,7 @@ import * as vscode from 'vscode'
 import { isTextPart, isToolCallPart } from '../server/handler'
 import { generateRandomId } from '../utils'
 import { logger } from '../utils/logger'
+import { parseDataUrl } from '../utils/url'
 
 /**
  * Anthropic APIのMessageCreateParamsリクエストを
@@ -73,6 +75,7 @@ export async function convertAnthropicRequestToVSCodeRequest(
         | string
         | Array<
             | vscode.LanguageModelTextPart
+            | vscode.LanguageModelDataPart
             | vscode.LanguageModelToolResultPart
             | vscode.LanguageModelToolCallPart
           > = ''
@@ -99,9 +102,7 @@ export async function convertAnthropicRequestToVSCodeRequest(
             case 'text':
               return new vscode.LanguageModelTextPart(c.text)
             case 'image':
-              return new vscode.LanguageModelTextPart(
-                `[Image] ${JSON.stringify(c)}`,
-              )
+              return convertImageBlockParamToLMPart(c)
             case 'tool_use':
               return new vscode.LanguageModelToolCallPart(
                 c.id,
@@ -118,9 +119,7 @@ export async function convertAnthropicRequestToVSCodeRequest(
                       case 'text':
                         return new vscode.LanguageModelTextPart(c.text)
                       case 'image':
-                        return new vscode.LanguageModelTextPart(
-                          `[Image] ${JSON.stringify(c)}`,
-                        )
+                        return convertImageBlockParamToLMPart(c)
                     }
                   }),
                 )
@@ -557,5 +556,24 @@ async function convertVSCodeTextToAnthropicMessage(
       service_tier: null,
     },
     // container: null
+  }
+}
+
+function convertImageBlockParamToLMPart(
+  c: ImageBlockParam,
+): vscode.LanguageModelDataPart | vscode.LanguageModelTextPart {
+  switch (c.source.type) {
+    case 'base64':
+      return vscode.LanguageModelDataPart.image(
+        Buffer.from(c.source.data, 'base64'),
+        c.source.media_type,
+      )
+    case 'url': {
+      const data = parseDataUrl(c.source.url)
+      if (data) {
+        return vscode.LanguageModelDataPart.image(data.data, data.mimeType)
+      }
+      return new vscode.LanguageModelTextPart(`[Image] ${JSON.stringify(c)}`)
+    }
   }
 }

--- a/src/converter/openaiConverter.ts
+++ b/src/converter/openaiConverter.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode'
 import { isTextPart, isToolCallPart } from '../server/handler'
 import { generateRandomId } from '../utils'
 import { logger } from '../utils/logger'
+import { parseDataUrl } from '../utils/url'
 
 /**
  * OpenAI APIのChatCompletionCreateParamsリクエストをVSCode拡張APIのチャットリクエスト形式に変換します。
@@ -37,6 +38,7 @@ export async function convertOpenAIRequestToVSCodeRequest(
         | string
         | Array<
             | vscode.LanguageModelTextPart
+            | vscode.LanguageModelDataPart
             | vscode.LanguageModelToolResultPart
             | vscode.LanguageModelToolCallPart
           > = ''
@@ -83,10 +85,18 @@ export async function convertOpenAIRequestToVSCodeRequest(
           switch (c.type) {
             case 'text':
               return new vscode.LanguageModelTextPart(c.text)
-            case 'image_url':
+            case 'image_url': {
+              const data = parseDataUrl(c.image_url.url)
+              if (data) {
+                return vscode.LanguageModelDataPart.image(
+                  data.data,
+                  data.mimeType,
+                )
+              }
               return new vscode.LanguageModelTextPart(
                 `[Image URL]: ${JSON.stringify(c.image_url)}`,
               )
+            }
             case 'input_audio':
               return new vscode.LanguageModelTextPart(
                 `[Input Audio]: ${JSON.stringify(c.input_audio)}`,

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,18 @@
+interface DataUrl {
+  mimeType: string
+  data: Uint8Array
+}
+
+export function parseDataUrl(dataUrl: string): DataUrl | null {
+  const match = dataUrl.match(/^data:(.+?);base64,(.+)$/)
+  if (!match) {
+    return null
+  }
+  const mimeType = match[1]
+  const base64Data = match[2]
+  const bytes = Buffer.from(base64Data, 'base64')
+  return {
+    mimeType,
+    data: bytes,
+  }
+}


### PR DESCRIPTION
素晴らしい拡張機能を公開いただきありがとうございます。
VSCode の LM API に新しく導入された LanguageModelDataPart を使って、画像の読み込みをサポートしました。

APIの詳細：[VS Code API | Visual Studio Code Extension API](https://code.visualstudio.com/api/references/vscode-api#LanguageModelDataPart)