### PR TITLE
fix: handle vscode-lm-proxy model ID for claude provider

### DIFF
--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -48,6 +48,8 @@ export async function getVSCodeModel(
         selectedModelId = modelManager.getOpenAIModelId()
       } else if (provider === 'anthropic') {
         selectedModelId = modelManager.getAnthropicModelId()
+      } else if (provider === 'claude') {
+        selectedModelId = modelManager.getClaudeCodeBackgroundModelId()
       }
 
       if (!selectedModelId) {
@@ -56,11 +58,17 @@ export async function getVSCodeModel(
     }
 
     // providerが'claude'の場合は、モデルIDに含まれる文字列を元にモデルを分岐
-    if (provider === 'claude') {
+    if (provider === 'claude' && modelId !== 'vscode-lm-proxy') {
       if (modelId.includes('haiku')) {
-        selectedModelId = modelManager.getClaudeCodeBackgroundModelId()
+        const backgroundModel = modelManager.getClaudeCodeBackgroundModelId()
+        if (backgroundModel) {
+          selectedModelId = backgroundModel
+        }
       } else if (modelId.includes('sonnet') || modelId.includes('opus')) {
-        selectedModelId = modelManager.getClaudeCodeThinkingModelId()
+        const thinkingModel = modelManager.getClaudeCodeThinkingModelId()
+        if (thinkingModel) {
+          selectedModelId = thinkingModel
+        }
       }
     }
 


### PR DESCRIPTION
## Problem
The Claude Code endpoint (`POST /anthropic/claude/v1/messages`) fails with a 404 error when using `"model": "vscode-lm-proxy"` in the request. The error indicates the model is not found in the VSCode Language Model API.

## Root Cause
The `getVSCodeModel()` function in `src/server/handler.ts` was missing a case to handle `provider === 'claude'` when `modelId === 'vscode-lm-proxy'`. This caused the function to pass `'vscode-lm-proxy'` directly to `vscode.lm.selectChatModels()` instead of resolving it to the actual selected Claude Code Background model.

## Solution
Added a check in the `if (modelId === 'vscode-lm-proxy')` condition to handle the Claude provider by resolving to the selected Claude Code Background model, matching the behavior for OpenAI and Anthropic providers.

## Changes
- `src/server/handler.ts`: Added Claude provider handling in `getVSCodeModel()` function

## Testing
The fix allows the Claude Code endpoint to properly resolve and use the selected Claude model when `vscode-lm-proxy` is specified as the model name.