### PR TITLE
feat: bind server to localhost by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,11 @@
           "maximum": 65535,
           "description": "Port number used by the LM Proxy server"
         },
+        "vscode-lm-proxy.host": {
+          "type": "string",
+          "default": "127.0.0.1",
+          "description": "Host address for the LM Proxy server. Use '0.0.0.0' to allow access from other devices on the network."
+        },
         "vscode-lm-proxy.logLevel": {
           "type": "number",
           "enum": [

--- a/src/server/manager.ts
+++ b/src/server/manager.ts
@@ -24,6 +24,15 @@ class ServerManager {
   }
 
   /**
+   * 設定からホストアドレスを取得
+   * @returns 設定されたホストアドレス（デフォルト: 127.0.0.1）
+   */
+  private getHost(): string {
+    const config = vscode.workspace.getConfiguration('vscode-lm-proxy')
+    return config.get<string>('host', '127.0.0.1')
+  }
+
+  /**
    * サーバーを起動する
    * @returns サーバー起動のPromise
    */
@@ -35,16 +44,17 @@ class ServerManager {
     try {
       const app = createServer()
       const port = this.getPort()
+      const host = this.getHost()
 
       return new Promise<void>((resolve, reject) => {
-        this.server = app.listen(port, () => {
+        this.server = app.listen(port, host, () => {
           this._isRunning = true
           vscode.commands.executeCommand(
             'setContext',
             'vscode-lm-proxy.serverRunning',
             true,
           )
-          logger.info(`VSCode LM Proxy server started on port ${port}`)
+          logger.info(`VSCode LM Proxy server started on ${host}:${port}`)
           statusBarManager.updateStatus(true)
           resolve()
         })
@@ -124,7 +134,7 @@ class ServerManager {
     if (!this._isRunning) {
       return null
     }
-    return `http://localhost:${this.getPort()}`
+    return `http://${this.getHost()}:${this.getPort()}`
   }
 }
 


### PR DESCRIPTION
## Summary
- Add `vscode-lm-proxy.host` setting (default: `127.0.0.1`) to control the server bind address
- Previously `app.listen(port)` bound to `0.0.0.0`, exposing the unauthenticated proxy to the local network
- Users who need LAN access can set host to `0.0.0.0`

Closes #20

## Changes
- `src/server/manager.ts`: Add `getHost()` method, pass host to `app.listen(port, host, ...)`
- `package.json`: Add `vscode-lm-proxy.host` configuration property

## Test plan
- [ ] Start server with default settings → verify it binds to `127.0.0.1:4000` (not `0.0.0.0`)
- [ ] Set `host` to `0.0.0.0` → verify LAN access works
- [ ] Verify `getServerUrl()` returns correct URL with configured host

🤖 Generated with [Claude Code](https://claude.com/claude-code)